### PR TITLE
bk_slave_mem_mode+nbk_unaligned

### DIFF
--- a/src/hvl_top/slave/axi4_slave_driver_proxy.sv
+++ b/src/hvl_top/slave/axi4_slave_driver_proxy.sv
@@ -582,6 +582,9 @@ task axi4_slave_driver_proxy::axi4_read_task();
      end
      else if (axi4_slave_agent_cfg_h.read_data_mode == SLAVE_MEM_MODE || axi4_slave_agent_cfg_h.read_data_mode == SLAVE_ERR_RESP_MODE && write_read_mode_h != ONLY_READ_DATA) begin
 
+      if(wr_addr_cnt != wr_resp_cnt)
+         completed_initial_txn=0;	
+
        wait(completed_initial_txn==1);
        //Converting transactions into struct data type
        axi4_slave_seq_item_converter::from_read_class(local_slave_rdata_tx,struct_read_packet);

--- a/src/hvl_top/test/sequences/master_sequences/axi4_master_nbk_read_unaligned_addr_seq.sv
+++ b/src/hvl_top/test/sequences/master_sequences/axi4_master_nbk_read_unaligned_addr_seq.sv
@@ -34,7 +34,8 @@ task axi4_master_nbk_read_unaligned_addr_seq::body();
   super.body();
 
   start_item(req);
-  if(!req.randomize() with {req.araddr % 4 !=0;
+  if(!req.randomize() with {//req.araddr % 4 !=0;
+                              req.araddr % 2**req.arsize !=0;
                               req.tx_type == READ;
                               req.arburst == READ_FIXED;
                               req.transfer_type == NON_BLOCKING_READ;}) begin

--- a/src/hvl_top/test/sequences/master_sequences/axi4_master_nbk_write_unaligned_addr_seq.sv
+++ b/src/hvl_top/test/sequences/master_sequences/axi4_master_nbk_write_unaligned_addr_seq.sv
@@ -35,8 +35,9 @@ task axi4_master_nbk_write_unaligned_addr_seq::body();
  
   start_item(req);
   if(!req.randomize() with {
-                             req.awsize == WRITE_2_BYTES;
-                             req.awaddr == (req.awaddr % 2**req.awsize != 0);
+                             //req.awsize == WRITE_2_BYTES;
+                             //req.awaddr == (req.awaddr % 2**req.awsize != 0);
+                             req.awaddr % 2**req.awsize != 0;
                              req.awlen == 11;
                              req.tx_type == WRITE;
                              req.awburst == WRITE_FIXED;


### PR DESCRIPTION
1. axi4_slave_driver_proxy.sv:
Problem: In the WRITE_RESPONSE_CHANNEL block of fork_join, the condition (wr_addr_cnt == wr_resp_cnt) was set to 1 as soon as wr_addr_cnt equals wr_resp_cnt. However, this condition was checked only after incrementing wr_resp_cnt, causing the condition to never evaluate as false.
Issue: When running a testcase with blocking type and read_data_mode set to SLAVE_MEM_MODE, the first read transaction occurred after the first write transaction was completed. However, the second read transaction did not wait for the second write to finish and instead read default values, because the condition (wr_addr_cnt == wr_resp_cnt) was already set as true and being checked only after wr_resp_cnt is incremented.
Solution: Modified the code to check the condition (wr_addr_cnt != wr_resp_cnt) inside the READ_DATA_CHANNEL block before the wait statement. This ensures that the read transaction waits until the corresponding write transaction is completed.
Fix: This modification resolves the issue by ensuring synchronization between the write and read transactions.

2. axi4_master_nbk_read_unaligned_addr_seq.sv:
Modified the inline constraints to allow unaligned addresses for all valid arsize values.

3. axi4_master_nbk_write_unaligned_addr_seq.sv:
Updated the inline constraint to correctly generate unaligned write addresses, as the existing constraint was returning only addresses 0 and 1.